### PR TITLE
add support for passing allowed custom methods

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	vegeta "github.com/tsenart/vegeta/lib"
+	vegeta "github.com/pusher/vegeta/lib"
 )
 
 func dumpCmd() command {

--- a/report.go
+++ b/report.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"strings"
 
-	vegeta "github.com/tsenart/vegeta/lib"
+	vegeta "github.com/pusher/vegeta/lib"
 )
 
 func reportCmd() command {


### PR DESCRIPTION
## Why?

http/2 allows using custom http verbs

## How?

- `vegeta attack` gets a new options `-allowed-methos=APPEND,DESTROY` which is a list of comma-separated verbs allowed in targets.